### PR TITLE
fix template unqualified lookup build errors on clang

### DIFF
--- a/Source/ImGui/Private/Utilities/WorldContext.h
+++ b/Source/ImGui/Private/Utilities/WorldContext.h
@@ -10,6 +10,9 @@
 
 namespace Utilities
 {
+	template<typename T>
+	FORCEINLINE const FWorldContext* GetWorldContext(const T* Obj);
+
 	FORCEINLINE const FWorldContext* GetWorldContext(const UGameInstance& GameInstance)
 	{
 		return GameInstance.GetWorldContext();
@@ -21,12 +24,6 @@ namespace Utilities
 		return Obj.IsValid() ? GetWorldContext(*Obj.Get()) : nullptr;
 	}
 
-	template<typename T>
-	FORCEINLINE const FWorldContext* GetWorldContext(const T* Obj)
-	{
-		return Obj ? GetWorldContext(*Obj) : nullptr;
-	}
-
 	FORCEINLINE const FWorldContext* GetWorldContext(const UGameViewportClient& GameViewportClient)
 	{
 		return GetWorldContext(GameViewportClient.GetGameInstance());
@@ -35,6 +32,12 @@ namespace Utilities
 	FORCEINLINE const FWorldContext* GetWorldContext(const UWorld& World)
 	{
 		return GetWorldContext(World.GetGameInstance());
+	}
+
+	template<typename T>
+	FORCEINLINE const FWorldContext* GetWorldContext(const T* Obj)
+	{
+		return Obj ? GetWorldContext(*Obj) : nullptr;
 	}
 
 	const FWorldContext* GetWorldContextFromNetMode(ENetMode NetMode);

--- a/Source/ImGui/Private/Utilities/WorldContextIndex.h
+++ b/Source/ImGui/Private/Utilities/WorldContextIndex.h
@@ -22,13 +22,6 @@ namespace Utilities
 	// Editor context index.
 	static constexpr int32 EDITOR_CONTEXT_INDEX = 0;
 
-	template<typename T>
-	FORCEINLINE int32 GetWorldContextIndex(const T& Obj)
-	{
-		const FWorldContext* WorldContext = GetWorldContext(Obj);
-		return WorldContext ? GetWorldContextIndex(*WorldContext) : INVALID_CONTEXT_INDEX;
-	}
-
 	FORCEINLINE int32 GetWorldContextIndex(const FWorldContext& WorldContext)
 	{
 		// In standalone game (WorldType = Game) we have only one context with index 0 (see GAME_CONTEXT_INDEX).
@@ -49,6 +42,13 @@ namespace Utilities
 		default:
 			return INVALID_CONTEXT_INDEX;
 		}
+	}
+
+	template<typename T>
+	FORCEINLINE int32 GetWorldContextIndex(const T& Obj)
+	{
+		const FWorldContext* WorldContext = GetWorldContext(Obj);
+		return WorldContext ? GetWorldContextIndex(*WorldContext) : INVALID_CONTEXT_INDEX;
 	}
 
 	int32 GetWorldContextIndex(const UWorld& World)


### PR DESCRIPTION
I'm developing Unreal Engine (4.19) games on Clang/Linux and then porting over to Windows/MSVC. The plugin code builds fine on MSVC but not on Clang. It looks like MSVC swallows some invalid code. Please take a look at [Unqualified lookup in templates](https://clang.llvm.org/compatibility.html#dep_lookup).

This commits fixes those build errors on Clang which also builds fine on MSVC.