### PR TITLE
Fix Name initialized after DrawEven in ImGuiContextProxy

### DIFF
--- a/Source/ImGui/Private/ImGuiContextProxy.h
+++ b/Source/ImGui/Private/ImGuiContextProxy.h
@@ -107,7 +107,7 @@ private:
 	bool bIsDrawCalled = false;
 
 	uint32 LastFrameNumber = 0;
-
+	FString Name;
 	FSimpleMulticastDelegate DrawEvent;
 	FSimpleMulticastDelegate* SharedDrawEvent = nullptr;
 
@@ -115,6 +115,6 @@ private:
 
 	TArray<FImGuiDrawList> DrawLists;
 
-	FString Name;
+
 	std::string IniFilename;
 };


### PR DESCRIPTION
Error raised on rebuilding ImGui plugin on 4.22 with warn as error