### PR TITLE
Fix issue with ImGui popup/modal windows not being able to be closed …

### DIFF
--- a/Source/ImGui/Private/ImGuiContextProxy.cpp
+++ b/Source/ImGui/Private/ImGuiContextProxy.cpp
@@ -158,6 +158,8 @@ void FImGuiContextProxy::BeginFrame(float DeltaTime)
 
 		ImGui::NewFrame();
 
+		bWantsMouseCapture = IO.WantCaptureMouse;
+
 		bIsFrameStarted = true;
 		bIsDrawEarlyDebugCalled = false;
 		bIsDrawDebugCalled = false;

--- a/Source/ImGui/Private/ImGuiContextProxy.h
+++ b/Source/ImGui/Private/ImGuiContextProxy.h
@@ -53,6 +53,9 @@ public:
 	// Whether this context has mouse hovering any window (read once per frame during context update).
 	bool IsMouseHoveringAnyWindow() const { return bIsMouseHoveringAnyWindow; }
 
+	// Whether ImGui will use the mouse inputs.
+	bool WantsMouseCapture() const { return bWantsMouseCapture; }
+
 	// Cursor type desired by this context (updated once per frame during context update).
 	EMouseCursor::Type GetMouseCursor() const { return MouseCursor;  }
 
@@ -92,6 +95,8 @@ private:
 	bool bIsFrameStarted = false;
 	bool bIsDrawEarlyDebugCalled = false;
 	bool bIsDrawDebugCalled = false;
+
+	bool bWantsMouseCapture = false;
 
 	FImGuiInputState InputState;
 

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
@@ -390,13 +390,13 @@ void SImGuiWidget::ReturnFocus()
 void SImGuiWidget::UpdateInputState()
 {
 	auto& Properties = ModuleManager->GetProperties();
-	auto* ContextPropxy = ModuleManager->GetContextManager().GetContextProxy(ContextIndex);
+	auto* ContextProxy = ModuleManager->GetContextManager().GetContextProxy(ContextIndex);
 
 	const bool bEnableTransparentMouseInput = Properties.IsMouseInputShared()
 #if PLATFORM_ANDROID || PLATFORM_IOS
 		&& (FSlateApplication::Get().GetCursorPos() != FVector2D::ZeroVector)
 #endif
-		&& !(ContextPropxy->IsMouseHoveringAnyWindow() || ContextPropxy->HasActiveItem());
+		&& !(ContextProxy->WantsMouseCapture() || ContextProxy->HasActiveItem());
 	if (bTransparentMouseInput != bEnableTransparentMouseInput)
 	{
 		bTransparentMouseInput = bEnableTransparentMouseInput;


### PR DESCRIPTION
…in transparent mouse input mode. The issue was caused by relying on ImGui::IsWindowHovered to determine whether an ImGui window was being hovered over, which doesn't work as expected with popups and modals. The ImGui documentation instead recommends using ImGuiIO::WantCaptureMouse to determine mouse input forwarding, so now SImGuiWidget relies on this value to update it's transparent mouse input state.