### PR TITLE
Fix deprecation warnings in IsBindable

### DIFF
--- a/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
+++ b/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
@@ -40,8 +40,8 @@ namespace
 
 	bool IsBindable(const FKey& Key)
 	{
-		return Key.IsValid() && Key != EKeys::AnyKey && !Key.IsFloatAxis() && !Key.IsVectorAxis()
-			&& !Key.IsGamepadKey() && !Key.IsModifierKey() && !Key.IsMouseButton();
+		return Key.IsValid() && Key != EKeys::AnyKey && !Key.IsAxis1D() && !Key.IsAxis2D()
+			&& !Key.IsAxis3D() && !Key.IsGamepadKey() && !Key.IsModifierKey() && !Key.IsMouseButton();
 	}
 
 	void UpdatePlayerInput(UPlayerInput* PlayerInput, const FKeyBind& KeyBind)

--- a/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
+++ b/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
@@ -40,8 +40,13 @@ namespace
 
 	bool IsBindable(const FKey& Key)
 	{
+#if ENGINE_COMPATIBILITY_LEGACY_KEY_AXIS_API
+		return Key.IsValid() && Key != EKeys::AnyKey && !Key.IsFloatAxis() && !Key.IsVectorAxis()
+			&& !Key.IsGamepadKey() && !Key.IsModifierKey() && !Key.IsMouseButton();
+#else
 		return Key.IsValid() && Key != EKeys::AnyKey && !Key.IsAxis1D() && !Key.IsAxis2D()
 			&& !Key.IsAxis3D() && !Key.IsGamepadKey() && !Key.IsModifierKey() && !Key.IsMouseButton();
+#endif
 	}
 
 	void UpdatePlayerInput(UPlayerInput* PlayerInput, const FKeyBind& KeyBind)

--- a/Source/ImGui/Private/VersionCompatibility.h
+++ b/Source/ImGui/Private/VersionCompatibility.h
@@ -31,3 +31,5 @@
 // Starting from version 4.24, world actor tick event has additional world parameter.
 #define ENGINE_COMPATIBILITY_LEGACY_WORLD_ACTOR_TICK    BELOW_ENGINE_VERSION(4, 24)
 
+// Starting from version 4.26, FKey::IsFloatAxis and FKey::IsVectorAxis are deprecated and replaced with FKey::IsAxis[1|2|3]D methods.
+#define ENGINE_COMPATIBILITY_LEGACY_KEY_AXIS_API        BELOW_ENGINE_VERSION(4, 26)


### PR DESCRIPTION
Replaced `FKey::IsFloatAxis` and `FKey::IsVectorAxis` calls with the corresponding `FKey::IsAxis[1|2|3]D` method calls.

**Background**: `FKey::IsFloatAxis` and `FKey::IsVectorAxis` are marked as deprecated as of UE4.26, replaced with `FKey::IsAxis[1|2|3]D` methods.