### PR TITLE
Handle project overrides of PlayerInput class 

### DIFF
--- a/Source/ImGui/Private/ImGuiModuleSettings.h
+++ b/Source/ImGui/Private/ImGuiModuleSettings.h
@@ -9,7 +9,10 @@
 #include <InputCoreTypes.h>
 #include <Styling/SlateTypes.h>
 #include <UObject/Object.h>
+
+#if WITH_EDITOR
 #include <Interfaces/IPluginManager.h>
+#endif
 
 // We use FStringClassReference, which is supported by older and newer engine versions. Starting from 4.18, it is
 // a typedef of FSoftClassPath, which is also recognized by UHT.
@@ -282,8 +285,6 @@ public:
 
 private:
 
-	void OnPluginLoadingPhaseComplete(ELoadingPhase::Type Phase, bool bSucccess);
-
 	void InitializeAllSettings();
 	void UpdateSettings();
 	void UpdateDPIScaleInfo();
@@ -299,9 +300,10 @@ private:
 
 #if WITH_EDITOR
 	void OnPropertyChanged(class UObject* ObjectBeingModified, struct FPropertyChangedEvent& PropertyChangedEvent);
-#endif // WITH_EDITOR
+	void OnPluginLoadingPhaseComplete(ELoadingPhase::Type Phase, bool bSucccess);
 
 	FDelegateHandle PluginLoadingPhaseDelegateHandle;
+#endif // WITH_EDITOR
 	
 	FImGuiModuleProperties& Properties;
 	FImGuiModuleCommands& Commands;

--- a/Source/ImGui/Private/ImGuiModuleSettings.h
+++ b/Source/ImGui/Private/ImGuiModuleSettings.h
@@ -9,6 +9,7 @@
 #include <InputCoreTypes.h>
 #include <Styling/SlateTypes.h>
 #include <UObject/Object.h>
+#include <Interfaces/IPluginManager.h>
 
 // We use FStringClassReference, which is supported by older and newer engine versions. Starting from 4.18, it is
 // a typedef of FSoftClassPath, which is also recognized by UHT.
@@ -281,6 +282,8 @@ public:
 
 private:
 
+	void OnPluginLoadingPhaseComplete(ELoadingPhase::Type Phase, bool bSucccess);
+
 	void InitializeAllSettings();
 	void UpdateSettings();
 	void UpdateDPIScaleInfo();
@@ -298,6 +301,8 @@ private:
 	void OnPropertyChanged(class UObject* ObjectBeingModified, struct FPropertyChangedEvent& PropertyChangedEvent);
 #endif // WITH_EDITOR
 
+	FDelegateHandle PluginLoadingPhaseDelegateHandle;
+	
 	FImGuiModuleProperties& Properties;
 	FImGuiModuleCommands& Commands;
 

--- a/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
+++ b/Source/ImGui/Private/Utilities/DebugExecBindings.cpp
@@ -5,6 +5,7 @@
 #include "ImGuiModuleSettings.h"
 
 #include <GameFramework/PlayerInput.h>
+#include <GameFramework/InputSettings.h>
 #include <UObject/UObjectIterator.h>
 
 
@@ -86,7 +87,7 @@ namespace DebugExecBindings
 		const FKeyBind KeyBind = CreateKeyBind(KeyInfo, Command);
 
 		// Update default player input, so changes will be visible in all PIE sessions created after this point.
-		if (UPlayerInput* DefaultPlayerInput = GetMutableDefault<UPlayerInput>())
+		if (UPlayerInput* DefaultPlayerInput = GetMutableDefault<UPlayerInput>(UInputSettings::GetDefaultPlayerInputClass()))
 		{
 			UpdatePlayerInput(DefaultPlayerInput, KeyBind);
 		}


### PR DESCRIPTION
Using plugins like the Enhanced Input, you change the PlayerInput class to something that might not be loaded when ImGui is trying to bind settings for things like the F10 debug key. This change does two things:

1. Asks for the default player input class from the engines UInputSettings.
2. Delays trying to bind until after the plugin manager has completed the PreDefault stage (which is when both ImGui and EnhancedInput are loaded).