### PR TITLE
Updated for UE5 support.

### DIFF
--- a/ImGui.uplugin
+++ b/ImGui.uplugin
@@ -16,7 +16,7 @@
 	"Modules": [
 		{
 			"Name": "ImGui",
-			"Type": "Developer",
+			"Type": "DeveloperTool",
 			"LoadingPhase": "PreDefault"
 		}
 	]

--- a/Source/ImGui/Private/ImGuiContextProxy.cpp
+++ b/Source/ImGui/Private/ImGuiContextProxy.cpp
@@ -92,7 +92,7 @@ FImGuiContextProxy::FImGuiContextProxy(const FString& InName, int32 InContextInd
 
 	// Start with the default canvas size.
 	ResetDisplaySize();
-	IO.DisplaySize = { DisplaySize.X, DisplaySize.Y };
+	IO.DisplaySize = { (float)DisplaySize.X, (float)DisplaySize.Y };
 
 	// Set the initial DPI scale.
 	SetDPIScale(InDPIScale);
@@ -211,7 +211,7 @@ void FImGuiContextProxy::BeginFrame(float DeltaTime)
 		ImGuiInterops::CopyInput(IO, InputState);
 		InputState.ClearUpdateState();
 
-		IO.DisplaySize = { DisplaySize.X, DisplaySize.Y };
+		IO.DisplaySize = { (float)DisplaySize.X, (float)DisplaySize.Y };
 
 		ImGui::NewFrame();
 

--- a/Source/ImGui/Private/ImGuiContextProxy.h
+++ b/Source/ImGui/Private/ImGuiContextProxy.h
@@ -45,10 +45,10 @@ public:
 	void SetAsCurrent() { ImGui::SetCurrentContext(Context); }
 
 	// Get the desired context display size.
-	const FVector2D& GetDisplaySize() const { return DisplaySize; }
+	const FVector2f& GetDisplaySize() const { return DisplaySize; }
 
 	// Set the desired context display size.
-	void SetDisplaySize(const FVector2D& Size) { DisplaySize = Size; }
+	void SetDisplaySize(const FVector2f& Size) { DisplaySize = Size; }
 
 	// Reset the desired context display size to default size.
 	void ResetDisplaySize();
@@ -96,7 +96,7 @@ private:
 
 	ImGuiContext* Context;
 
-	FVector2D DisplaySize = FVector2D::ZeroVector;
+	FVector2f DisplaySize = FVector2f::ZeroVector;
 	float DPIScale = 1.f;
 
 	EMouseCursor::Type MouseCursor = EMouseCursor::None;

--- a/Source/ImGui/Private/ImGuiDrawData.cpp
+++ b/Source/ImGui/Private/ImGuiDrawData.cpp
@@ -24,7 +24,7 @@ void FImGuiDrawList::CopyVertexData(TArray<FSlateVertex>& OutVertexBuffer, const
 		SlateVertex.TexCoords[2] = SlateVertex.TexCoords[3] = 1.f;
 
 #if ENGINE_COMPATIBILITY_LEGACY_CLIPPING_API
-		const FVector2D VertexPosition = Transform.TransformPoint(ImGuiInterops::ToVector2D(ImGuiVertex.pos));
+		const FVector2f VertexPosition = Transform.TransformPoint(ImGuiInterops::ToVector2D(ImGuiVertex.pos));
 		SlateVertex.Position[0] = VertexPosition.X;
 		SlateVertex.Position[1] = VertexPosition.Y;
 		SlateVertex.ClipRect = VertexClippingRect;

--- a/Source/ImGui/Private/ImGuiImplementation.cpp
+++ b/Source/ImGui/Private/ImGuiImplementation.cpp
@@ -7,10 +7,12 @@
 // For convenience and easy access to the ImGui source code, we build it as part of this module.
 // We don't need to define IMGUI_API manually because it is already done for this module.
 
-#if PLATFORM_XBOXONE
-// Disable Win32 functions used in ImGui and not supported on XBox.
-#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS
-#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS
+#ifdef PLATFORM_XBOXONE
+	#if PLASTFORM_XBOXONE
+		// Disable Win32 functions used in ImGui and not supported on XBox.
+		#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS
+		#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS
+	#endif	// PLATFORM_XBOXONE
 #endif // PLATFORM_XBOXONE
 
 #if PLATFORM_WINDOWS

--- a/Source/ImGui/Private/ImGuiInputHandler.cpp
+++ b/Source/ImGui/Private/ImGuiInputHandler.cpp
@@ -152,7 +152,7 @@ FReply UImGuiInputHandler::OnMouseWheel(const FPointerEvent& MouseEvent)
 	return ToReply(true);
 }
 
-FReply UImGuiInputHandler::OnMouseMove(const FVector2D& MousePosition, const FPointerEvent& MouseEvent)
+FReply UImGuiInputHandler::OnMouseMove(const FVector2f& MousePosition, const FPointerEvent& MouseEvent)
 {
 	if (MouseEvent.IsTouchEvent())
 	{
@@ -162,26 +162,26 @@ FReply UImGuiInputHandler::OnMouseMove(const FVector2D& MousePosition, const FPo
 	return OnMouseMove(MousePosition);
 }
 
-FReply UImGuiInputHandler::OnMouseMove(const FVector2D& MousePosition)
+FReply UImGuiInputHandler::OnMouseMove(const FVector2f& MousePosition)
 {
 	InputState->SetMousePosition(MousePosition);
 	return ToReply(true);
 }
 
-FReply UImGuiInputHandler::OnTouchStarted(const FVector2D& CursorPosition, const FPointerEvent& TouchEvent)
+FReply UImGuiInputHandler::OnTouchStarted(const FVector2f& CursorPosition, const FPointerEvent& TouchEvent)
 {
 	InputState->SetTouchDown(true);
 	InputState->SetTouchPosition(CursorPosition);
 	return ToReply(true);
 }
 
-FReply UImGuiInputHandler::OnTouchMoved(const FVector2D& CursorPosition, const FPointerEvent& TouchEvent)
+FReply UImGuiInputHandler::OnTouchMoved(const FVector2f& CursorPosition, const FPointerEvent& TouchEvent)
 {
 	InputState->SetTouchPosition(CursorPosition);
 	return ToReply(true);
 }
 
-FReply UImGuiInputHandler::OnTouchEnded(const FVector2D& CursorPosition, const FPointerEvent& TouchEvent)
+FReply UImGuiInputHandler::OnTouchEnded(const FVector2f& CursorPosition, const FPointerEvent& TouchEvent)
 {
 	InputState->SetTouchDown(false);
 	return ToReply(true);

--- a/Source/ImGui/Private/ImGuiInputHandlerFactory.cpp
+++ b/Source/ImGui/Private/ImGuiInputHandlerFactory.cpp
@@ -9,7 +9,7 @@
 #include <InputCoreTypes.h>
 
 
-UImGuiInputHandler* FImGuiInputHandlerFactory::NewHandler(const FStringClassReference& HandlerClassReference, FImGuiModuleManager* ModuleManager, UGameViewportClient* GameViewport, int32 ContextIndex)
+UImGuiInputHandler* FImGuiInputHandlerFactory::NewHandler(const FSoftClassPath& HandlerClassReference, FImGuiModuleManager* ModuleManager, UGameViewportClient* GameViewport, int32 ContextIndex)
 {
 	UClass* HandlerClass = nullptr;
 	if (HandlerClassReference.IsValid())

--- a/Source/ImGui/Private/ImGuiInputHandlerFactory.h
+++ b/Source/ImGui/Private/ImGuiInputHandlerFactory.h
@@ -13,7 +13,7 @@ class FImGuiInputHandlerFactory
 {
 public:
 
-	static UImGuiInputHandler* NewHandler(const FStringClassReference& HandlerClassReference, FImGuiModuleManager* ModuleManager, UGameViewportClient* GameViewport, int32 ContextIndex);
+	static UImGuiInputHandler* NewHandler(const FSoftClassPath& HandlerClassReference, FImGuiModuleManager* ModuleManager, UGameViewportClient* GameViewport, int32 ContextIndex);
 
 	static void ReleaseHandler(UImGuiInputHandler* Handler);
 };

--- a/Source/ImGui/Private/ImGuiInputState.cpp
+++ b/Source/ImGui/Private/ImGuiInputState.cpp
@@ -78,7 +78,7 @@ void FImGuiInputState::ClearMouseButtons()
 
 void FImGuiInputState::ClearMouseAnalogue()
 {
-	MousePosition = FVector2D::ZeroVector;
+	MousePosition = FVector2f::ZeroVector;
 	MouseWheelDelta = 0.f;
 }
 

--- a/Source/ImGui/Private/ImGuiInputState.h
+++ b/Source/ImGui/Private/ImGuiInputState.h
@@ -82,11 +82,11 @@ public:
 	void AddMouseWheelDelta(float DeltaValue) { MouseWheelDelta += DeltaValue; }
 
 	// Get the mouse position.
-	const FVector2D& GetMousePosition() const { return MousePosition; }
+	const FVector2f& GetMousePosition() const { return MousePosition; }
 
 	// Set the mouse position.
 	// @param Position - Mouse position
-	void SetMousePosition(const FVector2D& Position) { MousePosition = Position; }
+	void SetMousePosition(const FVector2f& Position) { MousePosition = Position; }
 
 	// Check whether input has active mouse pointer.
 	bool HasMousePointer() const { return bHasMousePointer; }
@@ -107,11 +107,11 @@ public:
 	void SetTouchDown(bool bIsDown) { bTouchDown = bIsDown; }
 
 	// Get the touch position.
-	const FVector2D& GetTouchPosition() const { return TouchPosition; }
+	const FVector2f& GetTouchPosition() const { return TouchPosition; }
 
 	// Set the touch position.
 	// @param Position - Touch position
-	void SetTouchPosition(const FVector2D& Position) { TouchPosition = Position; }
+	void SetTouchPosition(const FVector2f& Position) { TouchPosition = Position; }
 
 	// Get Control down state.
 	bool IsControlDown() const { return bIsControlDown; }
@@ -213,8 +213,8 @@ private:
 	void ClearModifierKeys();
 	void ClearNavigationInputs();
 
-	FVector2D MousePosition = FVector2D::ZeroVector;
-	FVector2D TouchPosition = FVector2D::ZeroVector;
+	FVector2f MousePosition = FVector2f::ZeroVector;
+	FVector2f TouchPosition = FVector2f::ZeroVector;
 	float MouseWheelDelta = 0.f;
 
 	FMouseButtonsArray MouseButtonsDown;

--- a/Source/ImGui/Private/ImGuiInteroperability.h
+++ b/Source/ImGui/Private/ImGuiInteroperability.h
@@ -95,10 +95,10 @@ namespace ImGuiInterops
 		return FSlateRect{ ImGuiRect.x, ImGuiRect.y, ImGuiRect.z, ImGuiRect.w };
 	}
 
-	// Convert from ImVec2 rectangle to FVector2D.
-	FORCEINLINE FVector2D ToVector2D(const ImVec2& ImGuiVector)
+	// Convert from ImVec2 rectangle to FVector2f.
+	FORCEINLINE FVector2f ToVector2D(const ImVec2& ImGuiVector)
 	{
-		return FVector2D{ ImGuiVector.x, ImGuiVector.y };
+		return FVector2f{ ImGuiVector.x, ImGuiVector.y };
 	}
 
 	// Convert from ImGui Texture Id to Texture Index that we use for texture resources.

--- a/Source/ImGui/Private/ImGuiModuleSettings.cpp
+++ b/Source/ImGui/Private/ImGuiModuleSettings.cpp
@@ -128,7 +128,7 @@ void FImGuiModuleSettings::UpdateDPIScaleInfo()
 	}
 }
 
-void FImGuiModuleSettings::SetImGuiInputHandlerClass(const FStringClassReference& ClassReference)
+void FImGuiModuleSettings::SetImGuiInputHandlerClass(const FSoftClassPath& ClassReference)
 {
 	if (ImGuiInputHandlerClass != ClassReference)
 	{

--- a/Source/ImGui/Private/ImGuiModuleSettings.h
+++ b/Source/ImGui/Private/ImGuiModuleSettings.h
@@ -10,16 +10,9 @@
 #include <Styling/SlateTypes.h>
 #include <UObject/Object.h>
 
-// We use FStringClassReference, which is supported by older and newer engine versions. Starting from 4.18, it is
-// a typedef of FSoftClassPath, which is also recognized by UHT.
-#if ENGINE_COMPATIBILITY_LEGACY_STRING_CLASS_REF
-#include <StringClassReference.h>
-#else
 #include <UObject/SoftObjectPath.h>
-#endif
 
 #include "ImGuiModuleSettings.generated.h"
-
 
 /**
  * Struct containing key information that can be used for key binding. Using 'Undetermined' value for modifier keys
@@ -176,7 +169,7 @@ protected:
 	// Path to own implementation of ImGui Input Handler allowing to customize handling of keyboard and gamepad input.
 	// If not set then default handler is used.
 	UPROPERTY(EditAnywhere, config, Category = "Extensions", meta = (MetaClass = "ImGuiInputHandler"))
-	FStringClassReference ImGuiInputHandlerClass;
+	FSoftClassPath ImGuiInputHandlerClass;
 
 	// Whether ImGui should share keyboard input with game.
 	// This defines initial behaviour which can be later changed using 'ImGui.ToggleKeyboardInputSharing' command or
@@ -236,7 +229,7 @@ public:
 
 	// Generic delegate used to notify changes of boolean properties.
 	DECLARE_MULTICAST_DELEGATE_OneParam(FBoolChangeDelegate, bool);
-	DECLARE_MULTICAST_DELEGATE_OneParam(FStringClassReferenceChangeDelegate, const FStringClassReference&);
+	DECLARE_MULTICAST_DELEGATE_OneParam(FSoftClassPathChangeDelegate, const FSoftClassPath&);
 	DECLARE_MULTICAST_DELEGATE_OneParam(FImGuiCanvasSizeInfoChangeDelegate, const FImGuiCanvasSizeInfo&);
 	DECLARE_MULTICAST_DELEGATE_OneParam(FImGuiDPIScaleInfoChangeDelegate, const FImGuiDPIScaleInfo&);
 
@@ -253,7 +246,7 @@ public:
 	// event that are defined depending on needs.
 
 	// Get the path to custom implementation of ImGui Input Handler.
-	const FStringClassReference& GetImGuiInputHandlerClass() const { return ImGuiInputHandlerClass; }
+	const FSoftClassPath& GetImGuiInputHandlerClass() const { return ImGuiInputHandlerClass; }
 
 	// Get the software cursor configuration.
 	bool UseSoftwareCursor() const { return bUseSoftwareCursor; }
@@ -268,7 +261,7 @@ public:
 	const FImGuiDPIScaleInfo& GetDPIScaleInfo() const { return DPIScale; }
 
 	// Delegate raised when ImGui Input Handle is changed.
-	FStringClassReferenceChangeDelegate OnImGuiInputHandlerClassChanged;
+	FSoftClassPathChangeDelegate OnImGuiInputHandlerClassChanged;
 
 	// Delegate raised when software cursor configuration is changed.
 	FBoolChangeDelegate OnUseSoftwareCursorChanged;
@@ -285,7 +278,7 @@ private:
 	void UpdateSettings();
 	void UpdateDPIScaleInfo();
 
-	void SetImGuiInputHandlerClass(const FStringClassReference& ClassReference);
+	void SetImGuiInputHandlerClass(const FSoftClassPath& ClassReference);
 	void SetShareKeyboardInput(bool bShare);
 	void SetShareGamepadInput(bool bShare);
 	void SetShareMouseInput(bool bShare);
@@ -301,7 +294,7 @@ private:
 	FImGuiModuleProperties& Properties;
 	FImGuiModuleCommands& Commands;
 
-	FStringClassReference ImGuiInputHandlerClass;
+	FSoftClassPath ImGuiInputHandlerClass;
 	FImGuiKeyInfo ToggleInputKey;
 	FImGuiCanvasSizeInfo CanvasSize;
 	FImGuiDPIScaleInfo DPIScale;

--- a/Source/ImGui/Private/Widgets/SImGuiCanvasControl.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiCanvasControl.cpp
@@ -41,7 +41,7 @@ namespace
 
 		DRAG_DROP_OPERATOR_TYPE(FImGuiDragDropOperation, FDragDropOperation)
 
-			FImGuiDragDropOperation(const FVector2D& InPosition, const FVector2D& InOffset, EDragType InDragType)
+			FImGuiDragDropOperation(const FVector2f& InPosition, const FVector2f& InOffset, EDragType InDragType)
 			: StartPosition(InPosition)
 			, StartOffset(InOffset)
 			, DragType(InDragType)
@@ -50,8 +50,8 @@ namespace
 			MouseCursor = EMouseCursor::GrabHandClosed;
 		}
 
-		FVector2D StartPosition;
-		FVector2D StartOffset;
+		FVector2f StartPosition;
+		FVector2f StartOffset;
 		EDragType DragType;
 	};
 }
@@ -86,7 +86,7 @@ void SImGuiCanvasControl::Tick(const FGeometry& AllottedGeometry, const double I
 	{
 		if (FMath::IsNearlyEqual(CanvasScale, 1.f, ZoomScrollSpeed) && CanvasOffset.IsNearlyZero(1.f))
 		{
-			CanvasOffset = FVector2D::ZeroVector;
+			CanvasOffset = FVector2f::ZeroVector;
 			CanvasScale = 1.f;
 			Opacity = 0.f;
 			bBlendingOut = false;
@@ -94,7 +94,7 @@ void SImGuiCanvasControl::Tick(const FGeometry& AllottedGeometry, const double I
 		}
 		else
 		{
-			CanvasOffset = FMath::Lerp(CanvasOffset, FVector2D::ZeroVector, BlendOutSpeed);
+			CanvasOffset = FMath::Lerp(CanvasOffset, FVector2f::ZeroVector, BlendOutSpeed);
 			CanvasScale = FMath::Lerp(CanvasScale, 1.f, BlendOutSpeed);
 			Opacity = FMath::Lerp(Opacity, 0.f, BlendOutSpeed);
 		}
@@ -176,7 +176,7 @@ FReply SImGuiCanvasControl::OnDragOver(const FGeometry& MyGeometry, const FDragD
 	if (Operation.IsValid())
 	{
 		const FSlateRenderTransform ScreenToWidget = MyGeometry.GetAccumulatedRenderTransform().Inverse();
-		const FVector2D DragDelta = ScreenToWidget.TransformVector(DragDropEvent.GetScreenSpacePosition() - Operation->StartPosition);
+		const FVector2f DragDelta = ScreenToWidget.TransformVector(DragDropEvent.GetScreenSpacePosition() - Operation->StartPosition);
 	
 		if (Operation->DragType == EDragType::Content)
 		{
@@ -223,9 +223,9 @@ namespace
 		return Color;
 	}
 
-	FORCEINLINE FVector2D Round(const FVector2D& Vec)
+	FORCEINLINE FVector2f Round(const FVector2f& Vec)
 	{
-		return FVector2D{ FMath::FloorToFloat(Vec.X), FMath::FloorToFloat(Vec.Y) };
+		return FVector2f{ FMath::FloorToFloat(Vec.X), FMath::FloorToFloat(Vec.Y) };
 	}
 }
 
@@ -237,7 +237,7 @@ int32 SImGuiCanvasControl::OnPaint(const FPaintArgs& Args, const FGeometry& Allo
 	const FSlateRenderTransform ImGuiToScreen = Transform.Concatenate(WidgetToScreen);
 
 	const FSlateRect CanvasRect = FSlateRect(
-		ImGuiToScreen.TransformPoint(FVector2D::ZeroVector),
+		ImGuiToScreen.TransformPoint(FVector2f::ZeroVector),
 		ImGuiToScreen.TransformPoint(ComputeDesiredSize(1.f)));
 	const FMargin CanvasMargin = CalculateInset(MyCullingRect, CanvasRect);
 
@@ -299,7 +299,7 @@ void SImGuiCanvasControl::UpdateVisibility()
 	SetVisibility(bActive ? EVisibility::Visible : bBlendingOut ? EVisibility::HitTestInvisible : EVisibility::Hidden);
 }
 
-void SImGuiCanvasControl::Zoom(const FGeometry& MyGeometry, const float Delta, const FVector2D& MousePosition)
+void SImGuiCanvasControl::Zoom(const FGeometry& MyGeometry, const float Delta, const FVector2f& MousePosition)
 {
 	// If blending out, then cancel.
 	bBlendingOut = false;
@@ -320,8 +320,8 @@ void SImGuiCanvasControl::Zoom(const FGeometry& MyGeometry, const float Delta, c
 		// 1) Around mouse: MousePosition
 		// 2) Fixed in top-left corner: MyGeometry.GetLayoutBoundingRect().GetTopLeft()
 		// 3) Fixed in centre: MyGeometry.GetLayoutBoundingRect().GetCenter()
-		const FVector2D PivotPoint = MyGeometry.GetAccumulatedRenderTransform().Inverse().TransformPoint(MousePosition);
-		const FVector2D Pivot = PivotPoint - CanvasOffset;
+		const FVector2f PivotPoint = MyGeometry.GetAccumulatedRenderTransform().Inverse().TransformPoint(MousePosition);
+		const FVector2f Pivot = PivotPoint - CanvasOffset;
 
 		CanvasOffset += Pivot * (OldCanvasScale - CanvasScale) / OldCanvasScale;
 	}
@@ -331,7 +331,7 @@ void SImGuiCanvasControl::Zoom(const FGeometry& MyGeometry, const float Delta, c
 
 void SImGuiCanvasControl::UpdateRenderTransform()
 {
-	const FVector2D RenderOffset = Round(ContentOffset * CanvasScale + CanvasOffset);
+	const FVector2f RenderOffset = Round(ContentOffset * CanvasScale + CanvasOffset);
 	Transform = FSlateRenderTransform(CanvasScale, RenderOffset);
 	OnTransformChanged.ExecuteIfBound(Transform);
 }

--- a/Source/ImGui/Private/Widgets/SImGuiCanvasControl.h
+++ b/Source/ImGui/Private/Widgets/SImGuiCanvasControl.h
@@ -67,7 +67,7 @@ private:
 
 	void UpdateVisibility();
 
-	void Zoom(const FGeometry& MyGeometry, const float Delta, const FVector2D& MousePosition);
+	void Zoom(const FGeometry& MyGeometry, const float Delta, const FVector2f& MousePosition);
 
 	void UpdateRenderTransform();
 
@@ -82,10 +82,10 @@ private:
 	FSlateRenderTransform Transform;
 
 	// Offset of the ImGui content in ImGui space.
-	FVector2D ContentOffset = FVector2D::ZeroVector;
+	FVector2f ContentOffset = FVector2f::ZeroVector;
 
 	// Offset of the ImGui canvas in widget local space.
-	FVector2D CanvasOffset = FVector2D::ZeroVector;
+	FVector2f CanvasOffset = FVector2f::ZeroVector;
 
 	// Scale of the ImGui canvas in widget local space.
 	float CanvasScale = 1.f;

--- a/Source/ImGui/Private/Widgets/SImGuiLayout.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiLayout.cpp
@@ -49,7 +49,7 @@ void SImGuiLayout::Construct(const FArguments& InArgs)
 				.Anchors(FAnchors(0.f, 0.f, 1.f, 1.f))
 				.AutoSize(true)
 				.Offset(FMargin(1.f, 1.f, 0.f, 1.f))
-				.Alignment(FVector2D::ZeroVector)
+				.Alignment(FVector2f::ZeroVector)
 				[
 					SNew(SImGuiWidget)
 					.ModuleManager(InArgs._ModuleManager)

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.cpp
@@ -63,19 +63,19 @@ namespace CVars
 
 namespace
 {
-	FORCEINLINE FVector2D MaxVector(const FVector2D& A, const FVector2D& B)
+	FORCEINLINE FVector2f MaxVector(const FVector2f& A, const FVector2f& B)
 	{
-		return FVector2D(FMath::Max(A.X, B.X), FMath::Max(A.Y, B.Y));
+		return FVector2f(FMath::Max(A.X, B.X), FMath::Max(A.Y, B.Y));
 	}
 
-	FORCEINLINE FVector2D RoundVector(const FVector2D& Vector)
+	FORCEINLINE FVector2f RoundVector(const FVector2f& Vector)
 	{
-		return FVector2D(FMath::RoundToFloat(Vector.X), FMath::RoundToFloat(Vector.Y));
+		return FVector2f(FMath::RoundToFloat(Vector.X), FMath::RoundToFloat(Vector.Y));
 	}
 
 	FORCEINLINE FSlateRenderTransform RoundTranslation(const FSlateRenderTransform& Transform)
 	{
-		return FSlateRenderTransform(Transform.GetMatrix(), RoundVector(Transform.GetTranslation()));
+		return FSlateRenderTransform(Transform.GetMatrix(), RoundVector(FVector2f(Transform.GetTranslation())));
 	}
 }
 
@@ -275,7 +275,7 @@ FReply SImGuiWidget::OnTouchEnded(const FGeometry& MyGeometry, const FPointerEve
 	return InputHandler->OnTouchEnded(TransformScreenPointToImGui(MyGeometry, TouchEvent.GetScreenSpacePosition()), TouchEvent);
 }
 
-void SImGuiWidget::CreateInputHandler(const FStringClassReference& HandlerClassReference)
+void SImGuiWidget::CreateInputHandler(const FSoftClassPath& HandlerClassReference)
 {
 	ReleaseInputHandler();
 
@@ -429,7 +429,7 @@ void SImGuiWidget::UpdateInputState()
 
 	const bool bEnableTransparentMouseInput = Properties.IsMouseInputShared()
 #if PLATFORM_ANDROID || PLATFORM_IOS
-		&& (FSlateApplication::Get().GetCursorPos() != FVector2D::ZeroVector)
+		&& (FSlateApplication::Get().GetCursorPos() != FVector2f::ZeroVector)
 #endif
 		&& !(ContextProxy->WantsMouseCapture() || ContextProxy->HasActiveItem());
 	if (bTransparentMouseInput != bEnableTransparentMouseInput)
@@ -553,14 +553,14 @@ void SImGuiWidget::SetCanvasSizeInfo(const FImGuiCanvasSizeInfo& CanvasSizeInfo)
 
 		case EImGuiCanvasSizeType::Desktop:
 			MinCanvasSize = (GEngine && GEngine->GameUserSettings)
-				? GEngine->GameUserSettings->GetDesktopResolution() : FVector2D::ZeroVector;
+				? GEngine->GameUserSettings->GetDesktopResolution() : FVector2f::ZeroVector;
 			bAdaptiveCanvasSize = CanvasSizeInfo.bExtendToViewport;
 			bCanvasControlEnabled = true;
 			break;
 
 		case EImGuiCanvasSizeType::Viewport:
 		default:
-			MinCanvasSize = FVector2D::ZeroVector;
+			MinCanvasSize = FVector2f::ZeroVector;
 			bAdaptiveCanvasSize = true;
 			bCanvasControlEnabled = false;
 	}
@@ -586,7 +586,7 @@ void SImGuiWidget::UpdateCanvasSize()
 			{
 				FVector2D ViewportSize;
 				GameViewport->GetViewportSize(ViewportSize);
-				CanvasSize = MaxVector(CanvasSize, ViewportSize);
+				CanvasSize = MaxVector(CanvasSize, FVector2f(ViewportSize));
 			}
 			else
 			{
@@ -617,7 +617,7 @@ void SImGuiWidget::OnPostImGuiUpdate()
 	UpdateMouseCursor();
 }
 
-FVector2D SImGuiWidget::TransformScreenPointToImGui(const FGeometry& MyGeometry, const FVector2D& Point) const
+FVector2f SImGuiWidget::TransformScreenPointToImGui(const FGeometry& MyGeometry, const FVector2f& Point) const
 {
 	const FSlateRenderTransform ImGuiToScreen = ImGuiTransform.Concatenate(MyGeometry.GetAccumulatedRenderTransform());
 	return ImGuiToScreen.Inverse().TransformPoint(Point);
@@ -689,7 +689,7 @@ int32 SImGuiWidget::OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeo
 
 FVector2D SImGuiWidget::ComputeDesiredSize(float Scale) const
 {
-	return CanvasSize * Scale;
+	return FVector2D(CanvasSize*Scale);
 }
 
 #if IMGUI_WIDGET_DEBUG
@@ -813,7 +813,7 @@ namespace TwoColumns
 	}
 
 	template<typename LabelType>
-	static void ValueWidthHeight(LabelType&& Label, const FVector2D& Value)
+	static void ValueWidthHeight(LabelType&& Label, const FVector2f& Value)
 	{
 		Text(Label); ImGui::NextColumn();
 		ImGui::Text("Width = %.0f, Height = %.0f", Value.X, Value.Y); ImGui::NextColumn();

--- a/Source/ImGui/Private/Widgets/SImGuiWidget.h
+++ b/Source/ImGui/Private/Widgets/SImGuiWidget.h
@@ -84,7 +84,7 @@ public:
 
 private:
 
-	void CreateInputHandler(const FStringClassReference& HandlerClassReference);
+	void CreateInputHandler(const FSoftClassPath& HandlerClassReference);
 	void ReleaseInputHandler();
 
 	void RegisterImGuiSettingsDelegates();
@@ -118,7 +118,7 @@ private:
 
 	void OnPostImGuiUpdate();
 
-	FVector2D TransformScreenPointToImGui(const FGeometry& MyGeometry, const FVector2D& Point) const;
+	FVector2f TransformScreenPointToImGui(const FGeometry& MyGeometry, const FVector2f& Point) const;
 
 	virtual int32 OnPaint(const FPaintArgs& Args, const FGeometry& AllottedGeometry, const FSlateRect& MyClippingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& WidgetStyle, bool bParentEnabled) const override;
 
@@ -142,8 +142,8 @@ private:
 
 	int32 ContextIndex = 0;
 
-	FVector2D MinCanvasSize = FVector2D::ZeroVector;
-	FVector2D CanvasSize = FVector2D::ZeroVector;
+	FVector2f MinCanvasSize = FVector2f::ZeroVector;
+	FVector2f CanvasSize = FVector2f::ZeroVector;
 
 	float DPIScale = 1.f;
 

--- a/Source/ImGui/Public/ImGuiInputHandler.h
+++ b/Source/ImGui/Public/ImGuiInputHandler.h
@@ -87,8 +87,8 @@ public:
 	 * @param MouseEvent Optional mouse event passed from Slate
 	 * @returns Response whether the event was handled
 	 */
-	virtual FReply OnMouseMove(const FVector2D& MousePosition, const FPointerEvent& MouseEvent);
-	virtual FReply OnMouseMove(const FVector2D& MousePosition);
+	virtual FReply OnMouseMove(const FVector2f& MousePosition, const FPointerEvent& MouseEvent);
+	virtual FReply OnMouseMove(const FVector2f& MousePosition);
 
 	/**
 	 * Called to handle touch started event.
@@ -96,7 +96,7 @@ public:
 	 * @param TouchEvent Touch event passed from Slate
 	 * @returns Response whether the event was handled
 	 */
-	virtual FReply OnTouchStarted(const FVector2D& TouchPosition, const FPointerEvent& TouchEvent);
+	virtual FReply OnTouchStarted(const FVector2f& TouchPosition, const FPointerEvent& TouchEvent);
 
 	/**
 	 * Called to handle touch moved event.
@@ -104,7 +104,7 @@ public:
 	 * @param TouchEvent Touch event passed from Slate
 	 * @returns Response whether the event was handled
 	 */
-	virtual FReply OnTouchMoved(const FVector2D& TouchPosition, const FPointerEvent& TouchEvent);
+	virtual FReply OnTouchMoved(const FVector2f& TouchPosition, const FPointerEvent& TouchEvent);
 
 	/**
 	 * Called to handle touch ended event.
@@ -112,7 +112,7 @@ public:
 	 * @param TouchEvent Touch event passed from Slate
 	 * @returns Response whether the event was handled
 	 */
-	virtual FReply OnTouchEnded(const FVector2D& TouchPosition, const FPointerEvent& TouchEvent);
+	virtual FReply OnTouchEnded(const FVector2f& TouchPosition, const FPointerEvent& TouchEvent);
 
 	/** Called to handle activation of the keyboard input. */
 	virtual void OnKeyboardInputEnabled();


### PR DESCRIPTION
Updated code to compile with UE5 and fixed all deprecated structure references.
 - This was primarily with regard to the addition of FVector2f in place of FVector2D (except in Slate).
 - NOTE: this may break any projects dependent on UE 4.18 or earlier.